### PR TITLE
refactor(domain): introduce abstract base classes for value objects

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -27,7 +27,7 @@ This document serves as the **main index** for all architectural decisions made 
 | [ADR-015](./docs/architecture/adr/ADR-015-domain-validation-error-hierarchy.md)        | Domain Validation Errors         | ✅ Accepted | 2026-03-11 | `DomainValidationError` subclasses instead of plain error objects                   |
 | [ADR-016](./docs/architecture/adr/ADR-016-ports-adapters-notification.md)              | Ports & Adapters Notification    | ✅ Accepted | 2026-03-12 | Ports & Adapters for cross-cutting notification between bounded contexts            |
 | [ADR-017](./docs/architecture/adr/ADR-017-application-layer-notification-ownership.md) | App Layer Notification Ownership | ✅ Accepted | 2026-03-12 | Application layer owns operation notifications triggered by CRUD actions            |
-| [ADR-018](./docs/architecture/adr/ADR-018-abstract-value-object-base-classes.md)       | Abstract VO Base Classes         | ✅ Accepted | 2026-05-05 | Abstract base classes with shared `public static` validation helpers for all VOs    |
+| [ADR-018](./docs/architecture/adr/ADR-018-abstract-value-object-base-classes.md)       | Abstract VO Base Classes         | ✅ Accepted | 2026-05-05 | Abstract base classes with shared `protected static` validation helpers for all VOs |
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -8,23 +8,26 @@ This document serves as the **main index** for all architectural decisions made 
 
 ## Quick Reference - All ADRs
 
-| ADR                                                                                    | Title                       | Status      | Date       | Description                                                                         |
-| -------------------------------------------------------------------------------------- | --------------------------- | ----------- | ---------- | ----------------------------------------------------------------------------------- |
-| [ADR-001](./docs/architecture/adr/ADR-001-starter-template-selection.md)               | Starter Template Selection  | ✅ Accepted | 2026-01-14 | Use @pplancq/react-app for Rsbuild foundation and architectural freedom             |
-| [ADR-002](./docs/architecture/adr/ADR-002-clean-architecture-ddd.md)                   | Clean Architecture + DDD    | ✅ Accepted | 2026-01-22 | Hybrid architecture with bounded contexts for scalability                           |
-| [ADR-003](./docs/architecture/adr/ADR-003-indexeddb-storage-strategy.md)               | IndexedDB Storage           | ✅ Accepted | 2026-01-22 | Offline-first storage with structured data and fast queries                         |
-| [ADR-004](./docs/architecture/adr/ADR-004-result-either-pattern.md)                    | Result/Either Pattern       | ✅ Accepted | 2026-02-03 | Type-safe error handling for domain operations                                      |
-| [ADR-005](./docs/architecture/adr/ADR-005-inversifyjs-dependency-injection.md)         | InversifyJS DI              | ✅ Accepted | 2026-02-02 | Dependency injection for loose coupling between layers                              |
-| [ADR-006](./docs/architecture/adr/ADR-006-pwa-from-day-one.md)                         | PWA from Day One            | ✅ Accepted | 2026-02-05 | Offline capabilities, installable app, performance optimization                     |
-| [ADR-007](./docs/architecture/adr/ADR-007-no-typescript-decorators.md)                 | No TypeScript Decorators    | ✅ Accepted | 2026-02-09 | Manual DI binding to maintain domain purity and avoid decorator side effects        |
-| [ADR-008](./docs/architecture/adr/ADR-008-result-pattern-usage-convention.md)          | Result Pattern Convention   | ✅ Accepted | 2026-02-09 | When to use Result vs throw: business errors vs programming errors                  |
-| [ADR-009](./docs/architecture/adr/ADR-009-symbol-based-service-identifiers.md)         | Symbol-based Service IDs    | ✅ Accepted | 2026-02-23 | Symbols as DI identifiers to avoid coupling and circular imports                    |
-| [ADR-010](./docs/architecture/adr/ADR-010-dto-date-type-conventions.md)                | DTO Date Type Conventions   | ✅ Accepted | 2026-02-23 | `Date` in application DTOs, `string \| null` in infrastructure DTOs                 |
-| [ADR-011](./docs/architecture/adr/ADR-011-map-centric-store-auto-trigger.md)           | Map-Centric Store           | ✅ Accepted | 2026-03-02 | Observable store with Map-based state and auto-triggered fetches via queueMicrotask |
-| [ADR-012](./docs/architecture/adr/ADR-012-page-layout-ownership-and-folder-pattern.md) | Page Layout Ownership       | ✅ Accepted | 2026-03-09 | Pages as autonomous layout-owning components + `<Name>/<Name>.tsx` convention       |
-| [ADR-013](./docs/architecture/adr/ADR-013-in-memory-repository-for-transient-data.md)  | In-Memory Repository        | ✅ Accepted | 2026-03-11 | Synchronous `Result<T, never>` + referential stability for transient data           |
-| [ADR-014](./docs/architecture/adr/ADR-014-infrastructure-id-generator.md)              | Infrastructure ID Generator | ✅ Accepted | 2026-03-11 | `IdGeneratorInterface` in domain, `CryptoIdGenerator` in infrastructure             |
-| [ADR-015](./docs/architecture/adr/ADR-015-domain-validation-error-hierarchy.md)        | Domain Validation Errors    | ✅ Accepted | 2026-03-11 | `DomainValidationError` subclasses instead of plain error objects                   |
+| ADR                                                                                    | Title                            | Status      | Date       | Description                                                                         |
+| -------------------------------------------------------------------------------------- | -------------------------------- | ----------- | ---------- | ----------------------------------------------------------------------------------- |
+| [ADR-001](./docs/architecture/adr/ADR-001-starter-template-selection.md)               | Starter Template Selection       | ✅ Accepted | 2026-01-14 | Use @pplancq/react-app for Rsbuild foundation and architectural freedom             |
+| [ADR-002](./docs/architecture/adr/ADR-002-clean-architecture-ddd.md)                   | Clean Architecture + DDD         | ✅ Accepted | 2026-01-22 | Hybrid architecture with bounded contexts for scalability                           |
+| [ADR-003](./docs/architecture/adr/ADR-003-indexeddb-storage-strategy.md)               | IndexedDB Storage                | ✅ Accepted | 2026-01-22 | Offline-first storage with structured data and fast queries                         |
+| [ADR-004](./docs/architecture/adr/ADR-004-result-either-pattern.md)                    | Result/Either Pattern            | ✅ Accepted | 2026-02-03 | Type-safe error handling for domain operations                                      |
+| [ADR-005](./docs/architecture/adr/ADR-005-inversifyjs-dependency-injection.md)         | InversifyJS DI                   | ✅ Accepted | 2026-02-02 | Dependency injection for loose coupling between layers                              |
+| [ADR-006](./docs/architecture/adr/ADR-006-pwa-from-day-one.md)                         | PWA from Day One                 | ✅ Accepted | 2026-02-05 | Offline capabilities, installable app, performance optimization                     |
+| [ADR-007](./docs/architecture/adr/ADR-007-no-typescript-decorators.md)                 | No TypeScript Decorators         | ✅ Accepted | 2026-02-09 | Manual DI binding to maintain domain purity and avoid decorator side effects        |
+| [ADR-008](./docs/architecture/adr/ADR-008-result-pattern-usage-convention.md)          | Result Pattern Convention        | ✅ Accepted | 2026-02-09 | When to use Result vs throw: business errors vs programming errors                  |
+| [ADR-009](./docs/architecture/adr/ADR-009-symbol-based-service-identifiers.md)         | Symbol-based Service IDs         | ✅ Accepted | 2026-02-23 | Symbols as DI identifiers to avoid coupling and circular imports                    |
+| [ADR-010](./docs/architecture/adr/ADR-010-dto-date-type-conventions.md)                | DTO Date Type Conventions        | ✅ Accepted | 2026-02-23 | `Date` in application DTOs, `string \| null` in infrastructure DTOs                 |
+| [ADR-011](./docs/architecture/adr/ADR-011-map-centric-store-auto-trigger.md)           | Map-Centric Store                | ✅ Accepted | 2026-03-02 | Observable store with Map-based state and auto-triggered fetches via queueMicrotask |
+| [ADR-012](./docs/architecture/adr/ADR-012-page-layout-ownership-and-folder-pattern.md) | Page Layout Ownership            | ✅ Accepted | 2026-03-09 | Pages as autonomous layout-owning components + `<Name>/<Name>.tsx` convention       |
+| [ADR-013](./docs/architecture/adr/ADR-013-in-memory-repository-for-transient-data.md)  | In-Memory Repository             | ✅ Accepted | 2026-03-11 | Synchronous `Result<T, never>` + referential stability for transient data           |
+| [ADR-014](./docs/architecture/adr/ADR-014-infrastructure-id-generator.md)              | Infrastructure ID Generator      | ✅ Accepted | 2026-03-11 | `IdGeneratorInterface` in domain, `CryptoIdGenerator` in infrastructure             |
+| [ADR-015](./docs/architecture/adr/ADR-015-domain-validation-error-hierarchy.md)        | Domain Validation Errors         | ✅ Accepted | 2026-03-11 | `DomainValidationError` subclasses instead of plain error objects                   |
+| [ADR-016](./docs/architecture/adr/ADR-016-ports-adapters-notification.md)              | Ports & Adapters Notification    | ✅ Accepted | 2026-03-12 | Ports & Adapters for cross-cutting notification between bounded contexts            |
+| [ADR-017](./docs/architecture/adr/ADR-017-application-layer-notification-ownership.md) | App Layer Notification Ownership | ✅ Accepted | 2026-03-12 | Application layer owns operation notifications triggered by CRUD actions            |
+| [ADR-018](./docs/architecture/adr/ADR-018-abstract-value-object-base-classes.md)       | Abstract VO Base Classes         | ✅ Accepted | 2026-05-05 | Abstract base classes with shared `public static` validation helpers for all VOs    |
 
 ---
 
@@ -64,6 +67,15 @@ This document serves as the **main index** for all architectural decisions made 
 - **ADR-013:** In-memory repository with `Result<T, never>` and referential stability
 - **ADR-014:** `IdGeneratorInterface` abstraction for infrastructure-agnostic ID generation
 - **ADR-015:** `DomainValidationError` hierarchy replacing plain error objects
+
+### Cross-Cutting Concerns (ADR-016, ADR-017)
+
+- **ADR-016:** Ports & Adapters for decoupled cross-cutting notification
+- **ADR-017:** Application layer owns operation notification responsibility
+
+### Domain Patterns (ADR-018)
+
+- **ADR-018:** Abstract base classes for Value Object validation helpers
 
 ---
 
@@ -105,6 +117,18 @@ This document serves as the **main index** for all architectural decisions made 
 - ADR-014: Infrastructure ID Generator Abstraction
 - ADR-015: Domain Validation Error Hierarchy
 
+### Issue #119 — Toast Bridge
+
+- ADR-016: Ports & Adapters for Cross-Cutting Notification
+
+### Issue #120 — Toast Usage
+
+- ADR-017: Application Layer Notification Ownership
+
+### Issue #285 — VO Refactoring
+
+- ADR-018: Abstract Base Classes for Value Object Validation
+
 ---
 
 ## ADR Status Legend
@@ -135,7 +159,7 @@ This document serves as the **main index** for all architectural decisions made 
 
 ---
 
-**Last Updated:** 2026-03-12  
-**Total ADRs:** 15 (All Accepted)  
+**Last Updated:** 2026-05-05  
+**Total ADRs:** 18 (All Accepted)  
 **Author:** Paul (with AI assistance)  
 **Project:** lab-clean-architecture-react

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Core architectural concepts and principles:
 - **[Folder Structure](./architecture/folder-structure.md)** - Detailed explanation of directory organization
 - **[Dependency Rules](./architecture/dependency-rules.md)** - Critical rules for maintaining clean dependencies
 - **[Dependency Injection](./architecture/dependency-injection.md)** - InversifyJS configuration and usage patterns
-- **[All ADRs →](./architecture/adr/README.md)** - 17 architectural decisions recorded
+- **[All ADRs →](./architecture/adr/README.md)** - 18 architectural decisions recorded
 
 ## 📚 Layers
 

--- a/docs/architecture/adr/ADR-018-abstract-value-object-base-classes.md
+++ b/docs/architecture/adr/ADR-018-abstract-value-object-base-classes.md
@@ -85,6 +85,8 @@ export class GameTitle extends AbstractStringValueObject {
 
 VOs with unique constraints add a `private static` method alongside the inherited helpers.
 
+> **Note on `private static` vs instance methods**: The general repository convention for helper methods that don't use `this` is to keep them as `private` instance methods and add `/* eslint-disable-next-line class-methods-use-this */` (see `DeleteGameUseCase`, `EditGameUseCase`). In VO subclasses this is an intentional exception: VOs are immutable value types with no mutable instance state, so `private static` is semantically correct and does not require disabling the ESLint rule.
+
 ### `Status` VO exception
 
 `Status` does **not** extend `AbstractStringValueObject` — its validation is enum-based (`AllowedValuesError`), not a string-length concern. It uses the shared error class directly without an abstract base.

--- a/docs/architecture/adr/ADR-018-abstract-value-object-base-classes.md
+++ b/docs/architecture/adr/ADR-018-abstract-value-object-base-classes.md
@@ -1,0 +1,114 @@
+# ADR-018: Abstract Base Classes for Value Object Validation
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+- **Issue:** [#285](https://github.com/pplancq/lab-clean-architecture-react/issues/285)
+
+## Context
+
+After ADR-015 introduced the `DomainValidationError` subclass hierarchy, each Value Object still repeated inline validation logic. All 6 collection VOs and 3 toast VOs contained nearly identical guards:
+
+```typescript
+// Duplicated across every VO
+if (!value || value.trim().length === 0) {
+  return Result.err(new NotEmptyError('title'));
+}
+if (value.trim().length > 200) {
+  return Result.err(new DomainValidationError('title', 'title cannot exceed 200 characters'));
+}
+```
+
+Problems:
+
+- Validation logic was copy-pasted — a bug fix or behaviour change had to be applied to every VO independently.
+- Inconsistent `trim()` behaviour: some VOs trimmed, some did not.
+- No `MaxLengthError` concrete class — long-string constraints fell back to the generic `DomainValidationError` with a manually written message.
+- `ToastDuration` used `value <= 0` which incorrectly passes `NaN` (because `NaN <= 0` evaluates to `false`).
+
+## Decision
+
+Introduce two abstract base classes in `src/shared/domain/value-objects/` and one new error class in `src/shared/domain/errors/`.
+
+### `MaxLengthError`
+
+A new concrete subclass of `DomainValidationError`:
+
+```typescript
+new MaxLengthError('title', 200);
+// → message: "title cannot exceed 200 characters"
+```
+
+### `AbstractStringValueObject`
+
+Abstract base for all string-based VOs. Exposes three `protected static` helpers:
+
+```typescript
+protected static trim(value: string): string
+protected static notEmpty(field: string, value: string): Result<string, NotEmptyError>
+protected static maxLength(field: string, value: string, max: number): Result<string, MaxLengthError>
+```
+
+### `AbstractNumberValueObject`
+
+Abstract base for numeric VOs. Exposes one `protected static` helper:
+
+```typescript
+protected static positiveNumber(field: string, value: number): Result<number, PositiveNumberError>
+```
+
+Uses `!Number.isFinite(value) || value < 1` — correctly rejects `NaN` and `Infinity`.
+
+### Usage pattern
+
+VOs extend the abstract base and compose helpers in their `create` factory:
+
+```typescript
+export class GameTitle extends AbstractStringValueObject {
+  private constructor(value: string) {
+    super(value);
+  }
+
+  public static create(value: string): Result<GameTitle, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('title', trimmed);
+    if (notEmptyCheck.isErr()) return Result.err(notEmptyCheck.getError());
+    const maxLengthCheck = AbstractStringValueObject.maxLength('title', trimmed, 200);
+    if (maxLengthCheck.isErr()) return Result.err(maxLengthCheck.getError());
+    return Result.ok(new GameTitle(trimmed));
+  }
+
+  public getTitle(): string {
+    return this.value;
+  }
+}
+```
+
+VOs with unique constraints add a `private static` method alongside the inherited helpers.
+
+### `Status` VO exception
+
+`Status` does **not** extend `AbstractStringValueObject` — its validation is enum-based (`AllowedValuesError`), not a string-length concern. It uses the shared error class directly without an abstract base.
+
+### Visibility: `protected static`
+
+Helpers are `protected static` — accessible within subclasses but not from external code. This enforces the VO public API: only `create()` and `getXXX()` are visible to callers. The validation helpers are implementation details of the VO class hierarchy.
+
+## Consequences
+
+**Easier:**
+
+- Validation logic lives in one place — a fix propagates to all VOs automatically.
+- New VOs compose existing helpers rather than repeating guards.
+- `MaxLengthError` is available for any VO needing a length constraint.
+- Consistent `trim()` behaviour across all string VOs.
+- `NaN`/`Infinity` edge case handled correctly by `AbstractNumberValueObject.positiveNumber`.
+
+**Trade-offs:**
+
+- All string/number VOs depend on the abstract base — changing the base affects all subclasses.
+- Tests that assert specific error message strings must be updated if default messages change (already accepted as a trade-off in ADR-015).
+
+## References
+
+- [ADR-015](./ADR-015-domain-validation-error-hierarchy.md) — Domain Validation Error Hierarchy
+- [Value Objects Guide](../../value-objects.md)

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -42,6 +42,7 @@ Each ADR follows this structure:
 | [ADR-015](./ADR-015-domain-validation-error-hierarchy.md)        | Domain Validation Error Hierarchy                 | ✅ Accepted | 2026-03-11 | Issue #118 Toast        |
 | [ADR-016](./ADR-016-ports-adapters-notification.md)              | Ports & Adapters for Cross-Cutting Notification   | ✅ Accepted | 2026-03-12 | Issue #119 Toast Bridge |
 | [ADR-017](./ADR-017-application-layer-notification-ownership.md) | Application Layer Owns Operation Notifications    | ✅ Accepted | 2026-03-12 | Issue #120 Toast Usage  |
+| [ADR-018](./ADR-018-abstract-value-object-base-classes.md)       | Abstract Base Classes for Value Object Validation | ✅ Accepted | 2026-05-05 | Issue #285              |
 
 ## Pending ADRs
 

--- a/docs/value-objects.md
+++ b/docs/value-objects.md
@@ -176,15 +176,24 @@ public static create(value: number): Result<ToastDuration, DomainValidationError
 
 ```typescript
 import { AllowedValuesError } from '@Shared/domain/errors/AllowedValuesError';
+import type { ToastTypeValue } from '../entities/ToastInterface';
 
-const ALLOWED = ['success', 'info', 'warning', 'error'] as const;
+export class ToastType {
+  private static readonly VALID_TYPES: ToastTypeValue[] = ['success', 'error', 'info', 'warning'];
 
-public static create(value: string): Result<ToastVariant, DomainValidationErrorInterface> {
-  if (!ALLOWED.includes(value as ToastVariantValue)) {
-    return Result.err(new AllowedValuesError('type', ALLOWED));
-    // → message: "type must be one of: success, info, warning, error"
+  private constructor(private readonly value: ToastTypeValue) {}
+
+  static create(value: string): Result<ToastType, DomainValidationErrorInterface> {
+    if (!this.VALID_TYPES.includes(value as ToastTypeValue)) {
+      return Result.err(new AllowedValuesError('type', this.VALID_TYPES));
+      // → message: "type must be one of: success, error, info, warning"
+    }
+    return Result.ok(new ToastType(value as ToastTypeValue));
   }
-  return Result.ok(new ToastVariant(value as ToastVariantValue));
+
+  getValue(): ToastTypeValue {
+    return this.value;
+  }
 }
 ```
 
@@ -407,21 +416,35 @@ export class GameDescription extends AbstractStringValueObject {
 Enum VOs do **not** extend `AbstractStringValueObject` — they use `AllowedValuesError` directly:
 
 ```typescript
-const ALLOWED_STATUSES = ['wishlist', 'owned', 'completed', 'abandoned'] as const;
-type StatusType = (typeof ALLOWED_STATUSES)[number];
+import { AllowedValuesError } from '@Shared/domain/errors/AllowedValuesError';
+
+export enum StatusType {
+  OWNED = 'Owned',
+  WISHLIST = 'Wishlist',
+  SOLD = 'Sold',
+  LOANED = 'Loaned',
+}
 
 export class Status {
-  private constructor(private readonly value: StatusType) {}
+  private readonly value: StatusType;
 
-  public static create(value: string): Result<Status, DomainValidationErrorInterface> {
-    if (!ALLOWED_STATUSES.includes(value as StatusType)) {
-      return Result.err(new AllowedValuesError('status', ALLOWED_STATUSES));
-      // → "status must be one of: wishlist, owned, completed, abandoned"
-    }
-    return Result.ok(new Status(value as StatusType));
+  private constructor(value: StatusType) {
+    this.value = value;
   }
 
-  public getStatus(): StatusType {
+  public static create(value: string): Result<Status, DomainValidationErrorInterface> {
+    const trimmedValue = value?.trim() ?? '';
+    const allowedValues = Object.values(StatusType);
+    const statusValue = allowedValues.find(s => s.toLowerCase() === trimmedValue.toLowerCase());
+
+    if (!statusValue) {
+      return Result.err(new AllowedValuesError('status', allowedValues));
+      // → "status must be one of: Owned, Wishlist, Sold, Loaned"
+    }
+    return Result.ok(new Status(statusValue as StatusType));
+  }
+
+  getStatus(): StatusType {
     return this.value;
   }
 }

--- a/docs/value-objects.md
+++ b/docs/value-objects.md
@@ -15,27 +15,28 @@ Value Objects are immutable objects that represent domain concepts through their
 
 ### Structure
 
+Value Objects extend the appropriate abstract base class from `@Shared/domain/value-objects/` and compose validation helpers in their static `create` factory.
+
 ```typescript
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 import { Result } from '@Shared/domain/result/Result';
-import { NotEmptyError } from '@Shared/domain/errors/NotEmptyError';
 import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 
-export class MyValue {
-  private readonly value: string;
-
+export class GameTitle extends AbstractStringValueObject {
   private constructor(value: string) {
-    this.value = value;
+    super(value);
   }
 
-  static create(value: string): Result<MyValue, DomainValidationErrorInterface> {
-    if (!value || value.trim().length === 0) {
-      return Result.err(new NotEmptyError('myValue'));
-    }
-
-    return Result.ok(new MyValue(value.trim()));
+  public static create(value: string): Result<GameTitle, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('title', trimmed);
+    if (notEmptyCheck.isErr()) return Result.err(notEmptyCheck.getError());
+    const maxLengthCheck = AbstractStringValueObject.maxLength('title', trimmed, 200);
+    if (maxLengthCheck.isErr()) return Result.err(maxLengthCheck.getError());
+    return Result.ok(new GameTitle(trimmed));
   }
 
-  getMyValue(): string {
+  public getTitle(): string {
     return this.value;
   }
 }
@@ -43,11 +44,44 @@ export class MyValue {
 
 ### Key Points
 
+- **Extends abstract base**: `AbstractStringValueObject` or `AbstractNumberValueObject` from `@Shared/domain/value-objects/`
 - **Private constructor**: Prevents invalid instantiation
 - **Static factory method**: Returns `Result<T, DomainValidationErrorInterface>` for validation
-- **Immutable properties**: All fields are `readonly`
-- **Single getter**: Returns the primitive value
+- **Immutable properties**: All fields are `readonly` (via `protected readonly value` on the base)
+- **Single getter**: Returns the primitive value with a domain-specific name
 - **Typed errors**: Use `DomainValidationError` subclasses — never plain objects
+
+## Abstract Base Classes
+
+Two abstract base classes are provided in `src/shared/domain/value-objects/`:
+
+### `AbstractStringValueObject`
+
+For all string-based VOs. Provides `protected static` helpers — accessible only within subclasses, not from external code:
+
+| Helper      | Signature                                             | Description                                       |
+| ----------- | ----------------------------------------------------- | ------------------------------------------------- |
+| `trim`      | `(value: string): string`                             | Trims whitespace; returns `''` for null/undefined |
+| `notEmpty`  | `(field, value): Result<string, NotEmptyError>`       | Fails if the trimmed string is empty              |
+| `maxLength` | `(field, value, max): Result<string, MaxLengthError>` | Fails if string exceeds `max` characters          |
+
+### `AbstractNumberValueObject`
+
+For numeric VOs. Provides one `protected static` helper:
+
+| Helper           | Signature                                             | Description                                                      |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------------------------------- |
+| `positiveNumber` | `(field, value): Result<number, PositiveNumberError>` | Fails if value is not finite or `< 1` (handles `NaN`/`Infinity`) |
+
+### Why `protected static`?
+
+Helpers are `protected` to enforce the VO public API contract: only `create()` and `getXXX()` are visible to callers. The validation helpers are implementation details of the class hierarchy and must not be called directly from outside a VO subclass.
+
+### When NOT to extend the abstract base
+
+`Status` does **not** extend `AbstractStringValueObject` because its validation is enum-based (allowed values), not a string-length concern. Use `AllowedValuesError` directly for enum VOs.
+
+See [ADR-018](./architecture/adr/ADR-018-abstract-value-object-base-classes.md) for rationale.
 
 ## Naming Conventions
 
@@ -103,28 +137,38 @@ Use `DomainValidationError` subclasses from `@Shared/domain/errors/` — never p
 ### Required String Values
 
 ```typescript
-import { NotEmptyError } from '@Shared/domain/errors/NotEmptyError';
+public static create(value: string): Result<GameTitle, DomainValidationErrorInterface> {
+  const trimmed = AbstractStringValueObject.trim(value);
+  const notEmptyCheck = AbstractStringValueObject.notEmpty('title', trimmed);
+  if (notEmptyCheck.isErr()) return Result.err(notEmptyCheck.getError());
+  return Result.ok(new GameTitle(trimmed));
+  // NotEmptyError message: "title cannot be empty"
+}
+```
 
-static create(value: string): Result<GameTitle, DomainValidationErrorInterface> {
-  if (!value || value.trim().length === 0) {
-    return Result.err(new NotEmptyError('title'));
-    // → message: "title cannot be empty"
-  }
-  return Result.ok(new GameTitle(value.trim()));
+### Required String Values with Max Length
+
+```typescript
+public static create(value: string): Result<GameTitle, DomainValidationErrorInterface> {
+  const trimmed = AbstractStringValueObject.trim(value);
+  const notEmptyCheck = AbstractStringValueObject.notEmpty('title', trimmed);
+  if (notEmptyCheck.isErr()) return Result.err(notEmptyCheck.getError());
+  const maxLengthCheck = AbstractStringValueObject.maxLength('title', trimmed, 200);
+  if (maxLengthCheck.isErr()) return Result.err(maxLengthCheck.getError());
+  return Result.ok(new GameTitle(trimmed));
+  // MaxLengthError message: "title cannot exceed 200 characters"
 }
 ```
 
 ### Numeric Values (must be positive)
 
 ```typescript
-import { PositiveNumberError } from '@Shared/domain/errors/PositiveNumberError';
-
-static create(value: number): Result<ToastDuration, DomainValidationErrorInterface> {
-  if (value <= 0) {
-    return Result.err(new PositiveNumberError('duration'));
-    // → message: "duration must be a positive number"
-  }
+public static create(value: number): Result<ToastDuration, DomainValidationErrorInterface> {
+  const check = AbstractNumberValueObject.positiveNumber('duration', value);
+  if (check.isErr()) return Result.err(check.getError());
   return Result.ok(new ToastDuration(value));
+  // PositiveNumberError message: "duration must be a positive number"
+  // Also handles NaN and Infinity correctly
 }
 ```
 
@@ -135,39 +179,42 @@ import { AllowedValuesError } from '@Shared/domain/errors/AllowedValuesError';
 
 const ALLOWED = ['success', 'info', 'warning', 'error'] as const;
 
-static create(value: string): Result<ToastType, DomainValidationErrorInterface> {
-  if (!ALLOWED.includes(value as ToastTypeValue)) {
+public static create(value: string): Result<ToastVariant, DomainValidationErrorInterface> {
+  if (!ALLOWED.includes(value as ToastVariantValue)) {
     return Result.err(new AllowedValuesError('type', ALLOWED));
     // → message: "type must be one of: success, info, warning, error"
   }
-  return Result.ok(new ToastType(value as ToastTypeValue));
+  return Result.ok(new ToastVariant(value as ToastVariantValue));
 }
 ```
 
 ### Optional String Values
 
 ```typescript
-static create(value: string): Result<GameDescription, DomainValidationErrorInterface> {
-  // Empty is valid (optional)
-  if (value.length > 1000) {
-    return Result.err(new DomainValidationError('description', 'Description cannot exceed 1000 characters'));
-  }
-  return Result.ok(new GameDescription(value));
+public static create(value: string): Result<GameDescription, DomainValidationErrorInterface> {
+  const trimmed = AbstractStringValueObject.trim(value);
+  // Empty is valid (optional field)
+  const maxLengthCheck = AbstractStringValueObject.maxLength('description', trimmed, 1000);
+  if (maxLengthCheck.isErr()) return Result.err(maxLengthCheck.getError());
+  return Result.ok(new GameDescription(trimmed));
+  // MaxLengthError message: "description cannot exceed 1000 characters"
 }
 ```
 
 ### Available Error Classes
 
-| Class                   | Location                 | Default message pattern                | Use case              |
-| ----------------------- | ------------------------ | -------------------------------------- | --------------------- |
-| `NotEmptyError`         | `@Shared/domain/errors/` | `"${field} cannot be empty"`           | Required strings      |
-| `PositiveNumberError`   | `@Shared/domain/errors/` | `"${field} must be a positive number"` | Numeric constraints   |
-| `AllowedValuesError`    | `@Shared/domain/errors/` | `"${field} must be one of: …"`         | Enum/fixed-set values |
-| `DomainValidationError` | `@Shared/domain/errors/` | Custom message required                | Other constraints     |
+| Class                   | Location                 | Default message pattern                      | Use case              |
+| ----------------------- | ------------------------ | -------------------------------------------- | --------------------- |
+| `NotEmptyError`         | `@Shared/domain/errors/` | `"${field} cannot be empty"`                 | Required strings      |
+| `MaxLengthError`        | `@Shared/domain/errors/` | `"${field} cannot exceed ${max} characters"` | String length limit   |
+| `PositiveNumberError`   | `@Shared/domain/errors/` | `"${field} must be a positive number"`       | Numeric constraints   |
+| `AllowedValuesError`    | `@Shared/domain/errors/` | `"${field} must be one of: …"`               | Enum/fixed-set values |
+| `DomainValidationError` | `@Shared/domain/errors/` | Custom message required                      | Other constraints     |
 
 All classes extend `DomainValidationError extends Error implements DomainValidationErrorInterface`. They accept an optional last argument to override the default message.
 
-See [ADR-015](./architecture/adr/ADR-015-domain-validation-error-hierarchy.md) for rationale.
+See [ADR-015](./architecture/adr/ADR-015-domain-validation-error-hierarchy.md) for error hierarchy rationale.
+See [ADR-018](./architecture/adr/ADR-018-abstract-value-object-base-classes.md) for abstract base class rationale.
 
 ## Usage in Entities
 
@@ -204,7 +251,7 @@ export class Game {
 
 ```typescript
 export class Game {
-  static create(props: GameCreateProps): Result<Game, GameError> {
+  static create(props: GameCreateProps): Result<Game, DomainValidationErrorInterface> {
     // Accepts primitives
     const { id, title, platform, format, status } = props;
 
@@ -239,7 +286,7 @@ export class Game {
 
 ```typescript
 export class Game {
-  updateTitle(newTitle: string): Result<void, GameError> {
+  updateTitle(newTitle: string): Result<void, DomainValidationErrorInterface> {
     const titleResult = GameTitle.create(newTitle);
     if (titleResult.isErr()) {
       return Result.err(titleResult.getError());
@@ -249,7 +296,7 @@ export class Game {
     return Result.ok(undefined);
   }
 
-  updateStatus(newStatus: string): Result<void, GameError> {
+  updateStatus(newStatus: string): Result<void, DomainValidationErrorInterface> {
     const statusResult = Status.create(newStatus);
     if (statusResult.isErr()) {
       return Result.err(statusResult.getError());
@@ -315,15 +362,19 @@ const validateTitle = (value: string) => {
 ### ID Value Objects
 
 ```typescript
-class GameId {
-  static create(value: string): Result<GameId, GameIdError> {
-    if (!value || value.trim().length === 0) {
-      return Result.err({ field: 'id', message: 'ID is required' });
-    }
-    return Result.ok(new GameId(value));
+export class GameId extends AbstractStringValueObject {
+  private constructor(value: string) {
+    super(value);
   }
 
-  getId(): string {
+  public static create(value: string): Result<GameId, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('id', trimmed);
+    if (notEmptyCheck.isErr()) return Result.err(notEmptyCheck.getError());
+    return Result.ok(new GameId(trimmed));
+  }
+
+  public getId(): string {
     return this.value;
   }
 }
@@ -332,19 +383,20 @@ class GameId {
 ### Optional Text Value Objects
 
 ```typescript
-class GameDescription {
-  static create(value: string): Result<GameDescription, GameDescriptionError> {
-    // Empty is valid
-    if (value.length > 1000) {
-      return Result.err({
-        field: 'description',
-        message: 'Description too long',
-      });
-    }
-    return Result.ok(new GameDescription(value));
+export class GameDescription extends AbstractStringValueObject {
+  private constructor(value: string) {
+    super(value);
   }
 
-  getDescription(): string {
+  public static create(value: string): Result<GameDescription, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+    // Empty is valid (optional field)
+    const maxLengthCheck = AbstractStringValueObject.maxLength('description', trimmed, 1000);
+    if (maxLengthCheck.isErr()) return Result.err(maxLengthCheck.getError());
+    return Result.ok(new GameDescription(trimmed));
+  }
+
+  public getDescription(): string {
     return this.value;
   }
 }
@@ -352,22 +404,24 @@ class GameDescription {
 
 ### Enum Value Objects
 
-```typescript
-enum StatusType {
-  Active = 'Active',
-  Inactive = 'Inactive',
-}
+Enum VOs do **not** extend `AbstractStringValueObject` — they use `AllowedValuesError` directly:
 
-class Status {
-  static create(value: string): Result<Status, StatusError> {
-    const normalized = value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
-    if (!Object.values(StatusType).includes(normalized as StatusType)) {
-      return Result.err({ field: 'status', message: 'Invalid status' });
+```typescript
+const ALLOWED_STATUSES = ['wishlist', 'owned', 'completed', 'abandoned'] as const;
+type StatusType = (typeof ALLOWED_STATUSES)[number];
+
+export class Status {
+  private constructor(private readonly value: StatusType) {}
+
+  public static create(value: string): Result<Status, DomainValidationErrorInterface> {
+    if (!ALLOWED_STATUSES.includes(value as StatusType)) {
+      return Result.err(new AllowedValuesError('status', ALLOWED_STATUSES));
+      // → "status must be one of: wishlist, owned, completed, abandoned"
     }
-    return Result.ok(new Status(normalized as StatusType));
+    return Result.ok(new Status(value as StatusType));
   }
 
-  getStatus(): StatusType {
+  public getStatus(): StatusType {
     return this.value;
   }
 }
@@ -396,7 +450,7 @@ describe('GameTitle', () => {
 
       expect(result.isErr()).toBeTruthy();
       expect(result.getError().field).toBe('title');
-      expect(result.getError().message).toContain('required');
+      expect(result.getError().message).toContain('cannot be empty');
     });
 
     it('should trim whitespace', () => {
@@ -441,3 +495,5 @@ For each Value Object, test:
 - Domain-Driven Design by Eric Evans
 - [Martin Fowler - Value Object](https://martinfowler.com/bliki/ValueObject.html)
 - Project Result Pattern: [result-pattern.md](./result-pattern.md)
+- [ADR-015 — Domain Validation Error Hierarchy](./architecture/adr/ADR-015-domain-validation-error-hierarchy.md)
+- [ADR-018 — Abstract Base Classes for Value Object Validation](./architecture/adr/ADR-018-abstract-value-object-base-classes.md)

--- a/src/collection/domain/entities/Game.ts
+++ b/src/collection/domain/entities/Game.ts
@@ -1,3 +1,4 @@
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 import { Result } from '@Shared/domain/result/Result';
 import { GameId } from '../value-objects/GameId';
 import { GameTitle } from '../value-objects/GameTitle';
@@ -5,11 +6,6 @@ import { GameDescription } from '../value-objects/GameDescription';
 import { Platform } from '../value-objects/Platform';
 import { Format } from '../value-objects/Format';
 import { Status, StatusType } from '../value-objects/Status';
-
-type GameError = {
-  field: string;
-  message: string;
-};
 
 /**
  * Props for creating a Game entity (using primitives)
@@ -95,7 +91,7 @@ export class Game {
    * @param props - Game properties (primitives that will be converted to value objects)
    * @returns Result containing Game or validation error from any value object
    */
-  static create(props: GameCreateProps): Result<Game, GameError> {
+  static create(props: GameCreateProps): Result<Game, DomainValidationErrorInterface> {
     // Create and validate GameId
     const gameIdResult = GameId.create(props.id);
     if (gameIdResult.isErr()) {
@@ -184,7 +180,7 @@ export class Game {
    * @param newTitle - New title string for the game
    * @returns Result with void on success or validation error
    */
-  updateTitle(newTitle: string): Result<void, GameError> {
+  updateTitle(newTitle: string): Result<void, DomainValidationErrorInterface> {
     const titleResult = GameTitle.create(newTitle);
     if (titleResult.isErr()) {
       return Result.err(titleResult.getError());
@@ -200,7 +196,7 @@ export class Game {
    * @param newDescription - New description string for the game
    * @returns Result with void on success or validation error
    */
-  updateDescription(newDescription: string): Result<void, GameError> {
+  updateDescription(newDescription: string): Result<void, DomainValidationErrorInterface> {
     const descriptionResult = GameDescription.create(newDescription);
     if (descriptionResult.isErr()) {
       return Result.err(descriptionResult.getError());
@@ -225,7 +221,7 @@ export class Game {
    * @param newStatus - New status string for the game
    * @returns Result with void on success or validation error
    */
-  updateStatus(newStatus: string): Result<void, GameError> {
+  updateStatus(newStatus: string): Result<void, DomainValidationErrorInterface> {
     const statusResult = Status.create(newStatus);
     if (statusResult.isErr()) {
       return Result.err(statusResult.getError());

--- a/src/collection/domain/value-objects/Format.ts
+++ b/src/collection/domain/value-objects/Format.ts
@@ -1,9 +1,6 @@
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 import { Result } from '@Shared/domain/result/Result';
-
-type FormatError = {
-  field: 'format';
-  message: string;
-};
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 
 /**
  * Format value object representing the game format
@@ -25,11 +22,9 @@ type FormatError = {
  * }
  * ```
  */
-export class Format {
-  private readonly value: string;
-
+export class Format extends AbstractStringValueObject {
   private constructor(value: string) {
-    this.value = value;
+    super(value);
   }
 
   /**
@@ -38,24 +33,20 @@ export class Format {
    * @param value - The format name
    * @returns Result containing Format or validation error
    */
-  static create(value: string): Result<Format, FormatError> {
-    const trimmedValue = value?.trim() ?? '';
+  public static create(value: string): Result<Format, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
 
-    if (trimmedValue.length === 0) {
-      return Result.err({
-        field: 'format',
-        message: 'Format name is required',
-      });
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('format', trimmed);
+    if (notEmptyCheck.isErr()) {
+      return Result.err(notEmptyCheck.getError());
     }
 
-    if (trimmedValue.length > 50) {
-      return Result.err({
-        field: 'format',
-        message: 'Format name cannot exceed 50 characters',
-      });
+    const maxLengthCheck = AbstractStringValueObject.maxLength('format', trimmed, 50);
+    if (maxLengthCheck.isErr()) {
+      return Result.err(maxLengthCheck.getError());
     }
 
-    return Result.ok(new Format(trimmedValue));
+    return Result.ok(new Format(trimmed));
   }
 
   /**

--- a/src/collection/domain/value-objects/GameDescription.ts
+++ b/src/collection/domain/value-objects/GameDescription.ts
@@ -1,9 +1,6 @@
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 import { Result } from '@Shared/domain/result/Result';
-
-type GameDescriptionError = {
-  field: 'description';
-  message: string;
-};
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 
 /**
  * GameDescription value object representing a game description
@@ -11,6 +8,7 @@ type GameDescriptionError = {
  * Business rules:
  * - Can be empty (optional field)
  * - Cannot exceed 1000 characters
+ * - Automatically trims whitespace
  *
  * @example
  * ```typescript
@@ -21,11 +19,9 @@ type GameDescriptionError = {
  * }
  * ```
  */
-export class GameDescription {
-  private readonly value: string;
-
+export class GameDescription extends AbstractStringValueObject {
   private constructor(value: string) {
-    this.value = value;
+    super(value);
   }
 
   /**
@@ -34,15 +30,15 @@ export class GameDescription {
    * @param value - The description value
    * @returns Result containing GameDescription or validation error
    */
-  static create(value: string): Result<GameDescription, GameDescriptionError> {
-    if (value.length > 1000) {
-      return Result.err({
-        field: 'description',
-        message: 'Game description cannot exceed 1000 characters',
-      });
+  public static create(value: string): Result<GameDescription, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+
+    const maxLengthCheck = AbstractStringValueObject.maxLength('description', trimmed, 1000);
+    if (maxLengthCheck.isErr()) {
+      return Result.err(maxLengthCheck.getError());
     }
 
-    return Result.ok(new GameDescription(value));
+    return Result.ok(new GameDescription(trimmed));
   }
 
   /**

--- a/src/collection/domain/value-objects/GameId.ts
+++ b/src/collection/domain/value-objects/GameId.ts
@@ -1,9 +1,6 @@
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 import { Result } from '@Shared/domain/result/Result';
-
-type GameIdError = {
-  field: 'gameId';
-  message: string;
-};
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 
 /**
  * GameId value object representing a unique game identifier
@@ -21,11 +18,9 @@ type GameIdError = {
  * }
  * ```
  */
-export class GameId {
-  private readonly value: string;
-
+export class GameId extends AbstractStringValueObject {
   private constructor(value: string) {
-    this.value = value;
+    super(value);
   }
 
   /**
@@ -34,14 +29,15 @@ export class GameId {
    * @param value - The identifier value
    * @returns Result containing GameId or validation error
    */
-  static create(value: string): Result<GameId, GameIdError> {
-    if (!value || value.trim().length === 0) {
-      return Result.err({
-        field: 'gameId',
-        message: 'GameId cannot be empty',
-      });
+  public static create(value: string): Result<GameId, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('gameId', trimmed);
+    if (notEmptyCheck.isErr()) {
+      return Result.err(notEmptyCheck.getError());
     }
-    return Result.ok(new GameId(value.trim()));
+
+    return Result.ok(new GameId(trimmed));
   }
 
   /**

--- a/src/collection/domain/value-objects/GameTitle.ts
+++ b/src/collection/domain/value-objects/GameTitle.ts
@@ -1,9 +1,6 @@
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 import { Result } from '@Shared/domain/result/Result';
-
-type GameTitleError = {
-  field: 'title';
-  message: string;
-};
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 
 /**
  * GameTitle value object representing a game title
@@ -22,11 +19,9 @@ type GameTitleError = {
  * }
  * ```
  */
-export class GameTitle {
-  private readonly value: string;
-
+export class GameTitle extends AbstractStringValueObject {
   private constructor(value: string) {
-    this.value = value;
+    super(value);
   }
 
   /**
@@ -35,24 +30,20 @@ export class GameTitle {
    * @param value - The title value
    * @returns Result containing GameTitle or validation error
    */
-  static create(value: string): Result<GameTitle, GameTitleError> {
-    const trimmedValue = value.trim();
+  public static create(value: string): Result<GameTitle, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
 
-    if (trimmedValue.length === 0) {
-      return Result.err({
-        field: 'title',
-        message: 'Game title cannot be empty',
-      });
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('title', trimmed);
+    if (notEmptyCheck.isErr()) {
+      return Result.err(notEmptyCheck.getError());
     }
 
-    if (trimmedValue.length > 200) {
-      return Result.err({
-        field: 'title',
-        message: 'Game title cannot exceed 200 characters',
-      });
+    const maxLengthCheck = AbstractStringValueObject.maxLength('title', trimmed, 200);
+    if (maxLengthCheck.isErr()) {
+      return Result.err(maxLengthCheck.getError());
     }
 
-    return Result.ok(new GameTitle(trimmedValue));
+    return Result.ok(new GameTitle(trimmed));
   }
 
   /**

--- a/src/collection/domain/value-objects/Platform.ts
+++ b/src/collection/domain/value-objects/Platform.ts
@@ -1,9 +1,6 @@
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 import { Result } from '@Shared/domain/result/Result';
-
-type PlatformError = {
-  field: 'platform';
-  message: string;
-};
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 
 /**
  * Platform value object representing the gaming platform
@@ -25,11 +22,9 @@ type PlatformError = {
  * }
  * ```
  */
-export class Platform {
-  private readonly value: string;
-
+export class Platform extends AbstractStringValueObject {
   private constructor(value: string) {
-    this.value = value;
+    super(value);
   }
 
   /**
@@ -38,31 +33,20 @@ export class Platform {
    * @param value - The platform name
    * @returns Result containing Platform or validation error
    */
-  static create(value: string): Result<Platform, PlatformError> {
-    if (!value) {
-      return Result.err({
-        field: 'platform',
-        message: 'Platform name is required',
-      });
+  public static create(value: string): Result<Platform, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('platform', trimmed);
+    if (notEmptyCheck.isErr()) {
+      return Result.err(notEmptyCheck.getError());
     }
 
-    const trimmedValue = value.trim();
-
-    if (trimmedValue.length === 0) {
-      return Result.err({
-        field: 'platform',
-        message: 'Platform name is required',
-      });
+    const maxLengthCheck = AbstractStringValueObject.maxLength('platform', trimmed, 100);
+    if (maxLengthCheck.isErr()) {
+      return Result.err(maxLengthCheck.getError());
     }
 
-    if (trimmedValue.length > 100) {
-      return Result.err({
-        field: 'platform',
-        message: 'Platform name cannot exceed 100 characters',
-      });
-    }
-
-    return Result.ok(new Platform(trimmedValue));
+    return Result.ok(new Platform(trimmed));
   }
 
   /**

--- a/src/collection/domain/value-objects/Status.ts
+++ b/src/collection/domain/value-objects/Status.ts
@@ -1,3 +1,5 @@
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
+import { AllowedValuesError } from '@Shared/domain/errors/AllowedValuesError';
 import { Result } from '@Shared/domain/result/Result';
 
 export enum StatusType {
@@ -6,11 +8,6 @@ export enum StatusType {
   SOLD = 'Sold',
   LOANED = 'Loaned',
 }
-
-type StatusError = {
-  field: 'status';
-  message: string;
-};
 
 /**
  * Status value object representing the game ownership status
@@ -41,15 +38,13 @@ export class Status {
    * @param value - The status name (case-insensitive)
    * @returns Result containing Status or validation error
    */
-  static create(value: string): Result<Status, StatusError> {
+  public static create(value: string): Result<Status, DomainValidationErrorInterface> {
     const trimmedValue = value?.trim() ?? '';
-    const statusValue = Object.values(StatusType).find(s => s.toLowerCase() === trimmedValue.toLowerCase());
+    const allowedValues = Object.values(StatusType);
+    const statusValue = allowedValues.find(s => s.toLowerCase() === trimmedValue.toLowerCase());
 
     if (!statusValue) {
-      return Result.err({
-        field: 'status',
-        message: `Invalid status: ${value}. Valid statuses are: ${Object.values(StatusType).join(', ')}`,
-      });
+      return Result.err(new AllowedValuesError('status', allowedValues));
     }
 
     return Result.ok(new Status(statusValue as StatusType));
@@ -61,7 +56,7 @@ export class Status {
    * @param value - The status type enum
    * @returns Status instance
    */
-  static createFromEnum(value: StatusType): Status {
+  public static createFromEnum(value: StatusType): Status {
     return new Status(value);
   }
 

--- a/src/collection/infrastructure/persistence/mappers/GameMapper.ts
+++ b/src/collection/infrastructure/persistence/mappers/GameMapper.ts
@@ -1,11 +1,7 @@
 import { Game } from '@Collection/domain/entities/Game';
+import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
 import { Result } from '@Shared/domain/result/Result';
 import { GameDTO } from '../dtos/GameDTO';
-
-type GameError = {
-  field: string;
-  message: string;
-};
 
 /**
  * Mapper between Game entity and GameDTO
@@ -54,7 +50,7 @@ export class GameMapper {
    * }
    * ```
    */
-  static toDomain(dto: GameDTO): Result<Game, GameError> {
+  static toDomain(dto: GameDTO): Result<Game, DomainValidationErrorInterface> {
     return Game.create({
       id: dto.id,
       title: dto.title,

--- a/src/shared/domain/errors/MaxLengthError.ts
+++ b/src/shared/domain/errors/MaxLengthError.ts
@@ -1,0 +1,20 @@
+import { DomainValidationError } from './DomainValidationError';
+
+/**
+ * Validation error raised when a field value exceeds its maximum allowed length.
+ *
+ * @example
+ * ```typescript
+ * return Result.err(new MaxLengthError('title', 200));
+ * // message: "title cannot exceed 200 characters"
+ *
+ * return Result.err(new MaxLengthError('title', 200, 'Game title is too long'));
+ * // message: "Game title is too long"
+ * ```
+ */
+export class MaxLengthError extends DomainValidationError {
+  constructor(field: string, maxLength: number, message = `${field} cannot exceed ${maxLength} characters`) {
+    super(field, message);
+    this.name = 'MaxLengthError';
+  }
+}

--- a/src/shared/domain/value-objects/AbstractNumberValueObject.ts
+++ b/src/shared/domain/value-objects/AbstractNumberValueObject.ts
@@ -1,0 +1,38 @@
+import { PositiveNumberError } from '@Shared/domain/errors/PositiveNumberError';
+import { Result } from '@Shared/domain/result/Result';
+
+/**
+ * Abstract base class for number-based value objects.
+ *
+ * Provides reusable validation helpers as public static methods.
+ * Subclasses extend this class and call these helpers in their static `create` factory.
+ *
+ * @example
+ * ```typescript
+ * export class ToastDuration extends AbstractNumberValueObject {
+ *   private constructor(value: number) { super(value); }
+ *
+ *   public static create(value: number): Result<ToastDuration, DomainValidationErrorInterface> {
+ *     const check = AbstractNumberValueObject.positiveNumber('duration', value);
+ *     if (check.isErr()) return Result.err(check.getError());
+ *     return Result.ok(new ToastDuration(value));
+ *   }
+ * }
+ * ```
+ */
+export abstract class AbstractNumberValueObject {
+  protected constructor(protected readonly value: number) {}
+
+  /**
+   * Validates that a number is strictly positive (>= 1) and finite.
+   *
+   * @param field - Field name used in the error message
+   * @param value - The number to validate
+   */
+  protected static positiveNumber(field: string, value: number): Result<number, PositiveNumberError> {
+    if (!Number.isFinite(value) || value < 1) {
+      return Result.err(new PositiveNumberError(field));
+    }
+    return Result.ok(value);
+  }
+}

--- a/src/shared/domain/value-objects/AbstractNumberValueObject.ts
+++ b/src/shared/domain/value-objects/AbstractNumberValueObject.ts
@@ -4,7 +4,7 @@ import { Result } from '@Shared/domain/result/Result';
 /**
  * Abstract base class for number-based value objects.
  *
- * Provides reusable validation helpers as public static methods.
+ * Provides reusable validation helpers as protected static methods.
  * Subclasses extend this class and call these helpers in their static `create` factory.
  *
  * @example

--- a/src/shared/domain/value-objects/AbstractStringValueObject.ts
+++ b/src/shared/domain/value-objects/AbstractStringValueObject.ts
@@ -5,7 +5,7 @@ import { Result } from '@Shared/domain/result/Result';
 /**
  * Abstract base class for string-based value objects.
  *
- * Provides reusable validation helpers as public static methods.
+ * Provides reusable validation helpers as protected static methods.
  * Subclasses extend this class and call these helpers in their static `create` factory.
  *
  * @example

--- a/src/shared/domain/value-objects/AbstractStringValueObject.ts
+++ b/src/shared/domain/value-objects/AbstractStringValueObject.ts
@@ -1,0 +1,64 @@
+import { MaxLengthError } from '@Shared/domain/errors/MaxLengthError';
+import { NotEmptyError } from '@Shared/domain/errors/NotEmptyError';
+import { Result } from '@Shared/domain/result/Result';
+
+/**
+ * Abstract base class for string-based value objects.
+ *
+ * Provides reusable validation helpers as public static methods.
+ * Subclasses extend this class and call these helpers in their static `create` factory.
+ *
+ * @example
+ * ```typescript
+ * export class GameTitle extends AbstractStringValueObject {
+ *   private constructor(value: string) { super(value); }
+ *
+ *   public static create(value: string): Result<GameTitle, DomainValidationErrorInterface> {
+ *     const trimmed = AbstractStringValueObject.trim(value);
+ *     const notEmptyCheck = AbstractStringValueObject.notEmpty('title', trimmed);
+ *     if (notEmptyCheck.isErr()) return Result.err(notEmptyCheck.getError());
+ *     const maxLengthCheck = AbstractStringValueObject.maxLength('title', trimmed, 200);
+ *     if (maxLengthCheck.isErr()) return Result.err(maxLengthCheck.getError());
+ *     return Result.ok(new GameTitle(trimmed));
+ *   }
+ * }
+ * ```
+ */
+export abstract class AbstractStringValueObject {
+  protected constructor(protected readonly value: string) {}
+
+  /**
+   * Trims leading and trailing whitespace from a string.
+   * Returns an empty string when given null or undefined.
+   */
+  protected static trim(value: string): string {
+    return value?.trim() ?? '';
+  }
+
+  /**
+   * Validates that a (pre-trimmed) string is not empty.
+   *
+   * @param field - Field name used in the error message
+   * @param value - The trimmed string to validate
+   */
+  protected static notEmpty(field: string, value: string): Result<string, NotEmptyError> {
+    if (value.length === 0) {
+      return Result.err(new NotEmptyError(field));
+    }
+    return Result.ok(value);
+  }
+
+  /**
+   * Validates that a string does not exceed the given maximum length.
+   *
+   * @param field - Field name used in the error message
+   * @param value - The string to validate
+   * @param max - Maximum allowed character count (inclusive)
+   */
+  protected static maxLength(field: string, value: string, max: number): Result<string, MaxLengthError> {
+    if (value.length > max) {
+      return Result.err(new MaxLengthError(field, max));
+    }
+    return Result.ok(value);
+  }
+}

--- a/src/toast/domain/value-objects/ToastDuration.ts
+++ b/src/toast/domain/value-objects/ToastDuration.ts
@@ -1,21 +1,22 @@
 import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
-import { PositiveNumberError } from '@Shared/domain/errors/PositiveNumberError';
 import { Result } from '@Shared/domain/result/Result';
+import { AbstractNumberValueObject } from '@Shared/domain/value-objects/AbstractNumberValueObject';
 
 /**
  * ToastDuration value object representing the auto-dismiss delay in milliseconds.
  *
  * Business rules:
- * - Must be a strictly positive number
+ * - Must be a strictly positive finite number (>= 1)
  */
-export class ToastDuration {
-  private static readonly MIN_DURATION = 1;
+export class ToastDuration extends AbstractNumberValueObject {
+  private constructor(value: number) {
+    super(value);
+  }
 
-  private constructor(private readonly value: number) {}
-
-  static create(value: number): Result<ToastDuration, DomainValidationErrorInterface> {
-    if (value < this.MIN_DURATION) {
-      return Result.err(new PositiveNumberError('duration'));
+  public static create(value: number): Result<ToastDuration, DomainValidationErrorInterface> {
+    const check = AbstractNumberValueObject.positiveNumber('duration', value);
+    if (check.isErr()) {
+      return Result.err(check.getError());
     }
 
     return Result.ok(new ToastDuration(value));

--- a/src/toast/domain/value-objects/ToastId.ts
+++ b/src/toast/domain/value-objects/ToastId.ts
@@ -1,6 +1,6 @@
 import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
-import { NotEmptyError } from '@Shared/domain/errors/NotEmptyError';
 import { Result } from '@Shared/domain/result/Result';
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 
 /**
  * ToastId value object representing a unique toast identifier.
@@ -9,15 +9,20 @@ import { Result } from '@Shared/domain/result/Result';
  * - Cannot be empty or whitespace-only
  * - Automatically trims whitespace
  */
-export class ToastId {
-  private constructor(private readonly value: string) {}
+export class ToastId extends AbstractStringValueObject {
+  private constructor(value: string) {
+    super(value);
+  }
 
-  static create(value: string): Result<ToastId, DomainValidationErrorInterface> {
-    if (!value || value.trim().length === 0) {
-      return Result.err(new NotEmptyError('id'));
+  public static create(value: string): Result<ToastId, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('id', trimmed);
+    if (notEmptyCheck.isErr()) {
+      return Result.err(notEmptyCheck.getError());
     }
 
-    return Result.ok(new ToastId(value.trim()));
+    return Result.ok(new ToastId(trimmed));
   }
 
   getValue(): string {

--- a/src/toast/domain/value-objects/ToastMessage.ts
+++ b/src/toast/domain/value-objects/ToastMessage.ts
@@ -1,6 +1,6 @@
 import type { DomainValidationErrorInterface } from '@Shared/domain/errors/DomainValidationErrorInterface';
-import { NotEmptyError } from '@Shared/domain/errors/NotEmptyError';
 import { Result } from '@Shared/domain/result/Result';
+import { AbstractStringValueObject } from '@Shared/domain/value-objects/AbstractStringValueObject';
 
 /**
  * ToastMessage value object representing the notification text.
@@ -9,15 +9,20 @@ import { Result } from '@Shared/domain/result/Result';
  * - Cannot be empty or whitespace-only
  * - Automatically trims whitespace
  */
-export class ToastMessage {
-  private constructor(private readonly value: string) {}
+export class ToastMessage extends AbstractStringValueObject {
+  private constructor(value: string) {
+    super(value);
+  }
 
-  static create(value: string): Result<ToastMessage, DomainValidationErrorInterface> {
-    if (!value || value.trim().length === 0) {
-      return Result.err(new NotEmptyError('message'));
+  public static create(value: string): Result<ToastMessage, DomainValidationErrorInterface> {
+    const trimmed = AbstractStringValueObject.trim(value);
+
+    const notEmptyCheck = AbstractStringValueObject.notEmpty('message', trimmed);
+    if (notEmptyCheck.isErr()) {
+      return Result.err(notEmptyCheck.getError());
     }
 
-    return Result.ok(new ToastMessage(value.trim()));
+    return Result.ok(new ToastMessage(trimmed));
   }
 
   getValue(): string {

--- a/tests/e2e/add-game.test.ts
+++ b/tests/e2e/add-game.test.ts
@@ -25,20 +25,20 @@ describe('Add Game page', () => {
 
     await page.getByRole('button', { name: /add game/i }).click();
 
-    await expect(page.getByText('Game title cannot be empty')).toBeVisible();
-    await expect(page.getByText('Platform name is required')).toBeVisible();
+    await expect(page.getByText('title cannot be empty')).toBeVisible();
+    await expect(page.getByText('platform cannot be empty')).toBeVisible();
   });
 
   it('should clear validation error when the field is filled', async ({ page }) => {
     await page.goto('/add-game');
 
     await page.getByRole('button', { name: /add game/i }).click();
-    await expect(page.getByText('Game title cannot be empty')).toBeVisible();
+    await expect(page.getByText('title cannot be empty')).toBeVisible();
 
     await page.getByRole('textbox', { name: /game title/i }).fill('The Last of Us Part I');
     await page.getByRole('button', { name: /add game/i }).click();
 
-    await expect(page.getByText('Game title cannot be empty')).toBeHidden();
+    await expect(page.getByText('title cannot be empty')).toBeHidden();
   });
 
   it('should redirect to home page after successful submission', async ({ page }) => {

--- a/tests/unit/collection/domain/entities/Game.test.ts
+++ b/tests/unit/collection/domain/entities/Game.test.ts
@@ -69,7 +69,7 @@ describe('Game', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('title');
-      expect(error.message).toBe('Game title cannot be empty');
+      expect(error.message).toBe('title cannot be empty');
     });
 
     it('should return error for title exceeding 200 characters', () => {
@@ -87,7 +87,7 @@ describe('Game', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('title');
-      expect(error.message).toBe('Game title cannot exceed 200 characters');
+      expect(error.message).toBe('title cannot exceed 200 characters');
     });
 
     it('should return error for description exceeding 1000 characters', () => {
@@ -105,7 +105,7 @@ describe('Game', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('description');
-      expect(error.message).toBe('Game description cannot exceed 1000 characters');
+      expect(error.message).toBe('description cannot exceed 1000 characters');
     });
 
     it('should return error for empty platform', () => {
@@ -122,7 +122,7 @@ describe('Game', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('platform');
-      expect(error.message).toBe('Platform name is required');
+      expect(error.message).toBe('platform cannot be empty');
     });
 
     it('should return error for empty format', () => {
@@ -139,7 +139,7 @@ describe('Game', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('format');
-      expect(error.message).toBe('Format name is required');
+      expect(error.message).toBe('format cannot be empty');
     });
 
     it('should return error for invalid status', () => {

--- a/tests/unit/collection/domain/value-objects/Format.test.ts
+++ b/tests/unit/collection/domain/value-objects/Format.test.ts
@@ -34,7 +34,7 @@ describe('Format', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('format');
-      expect(error.message).toBe('Format name is required');
+      expect(error.message).toBe('format cannot be empty');
     });
 
     it('should return error for whitespace-only format', () => {
@@ -43,7 +43,7 @@ describe('Format', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('format');
-      expect(error.message).toBe('Format name is required');
+      expect(error.message).toBe('format cannot be empty');
     });
 
     it('should return error for format name exceeding 50 characters', () => {
@@ -53,7 +53,7 @@ describe('Format', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('format');
-      expect(error.message).toBe('Format name cannot exceed 50 characters');
+      expect(error.message).toBe('format cannot exceed 50 characters');
     });
 
     it('should accept format name with exactly 50 characters', () => {

--- a/tests/unit/collection/domain/value-objects/GameDescription.test.ts
+++ b/tests/unit/collection/domain/value-objects/GameDescription.test.ts
@@ -26,7 +26,7 @@ describe('GameDescription', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('description');
-      expect(error.message).toBe('Game description cannot exceed 1000 characters');
+      expect(error.message).toBe('description cannot exceed 1000 characters');
     });
 
     it('should accept description with exactly 1000 characters', () => {

--- a/tests/unit/collection/domain/value-objects/GameId.test.ts
+++ b/tests/unit/collection/domain/value-objects/GameId.test.ts
@@ -25,7 +25,7 @@ describe('GameId', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('gameId');
-      expect(error.message).toBe('GameId cannot be empty');
+      expect(error.message).toBe('gameId cannot be empty');
     });
 
     it('should return error for whitespace-only string', () => {
@@ -34,7 +34,7 @@ describe('GameId', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('gameId');
-      expect(error.message).toBe('GameId cannot be empty');
+      expect(error.message).toBe('gameId cannot be empty');
     });
   });
 

--- a/tests/unit/collection/domain/value-objects/GameTitle.test.ts
+++ b/tests/unit/collection/domain/value-objects/GameTitle.test.ts
@@ -25,7 +25,7 @@ describe('GameTitle', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('title');
-      expect(error.message).toBe('Game title cannot be empty');
+      expect(error.message).toBe('title cannot be empty');
     });
 
     it('should return error for whitespace-only string', () => {
@@ -34,7 +34,7 @@ describe('GameTitle', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('title');
-      expect(error.message).toBe('Game title cannot be empty');
+      expect(error.message).toBe('title cannot be empty');
     });
 
     it('should return error for title exceeding 200 characters', () => {
@@ -44,7 +44,7 @@ describe('GameTitle', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('title');
-      expect(error.message).toBe('Game title cannot exceed 200 characters');
+      expect(error.message).toBe('title cannot exceed 200 characters');
     });
 
     it('should accept title with exactly 200 characters', () => {

--- a/tests/unit/collection/domain/value-objects/Platform.test.ts
+++ b/tests/unit/collection/domain/value-objects/Platform.test.ts
@@ -41,7 +41,7 @@ describe('Platform', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('platform');
-      expect(error.message).toBe('Platform name is required');
+      expect(error.message).toBe('platform cannot be empty');
     });
 
     it('should return error for whitespace-only platform', () => {
@@ -50,7 +50,7 @@ describe('Platform', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('platform');
-      expect(error.message).toBe('Platform name is required');
+      expect(error.message).toBe('platform cannot be empty');
     });
 
     it('should return error for platform name exceeding 100 characters', () => {
@@ -60,7 +60,7 @@ describe('Platform', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('platform');
-      expect(error.message).toBe('Platform name cannot exceed 100 characters');
+      expect(error.message).toBe('platform cannot exceed 100 characters');
     });
 
     it('should accept platform name with exactly 100 characters', () => {

--- a/tests/unit/collection/domain/value-objects/Status.test.ts
+++ b/tests/unit/collection/domain/value-objects/Status.test.ts
@@ -34,7 +34,7 @@ describe('Status', () => {
       expect(result.isErr()).toBeTruthy();
       const error = result.getError();
       expect(error.field).toBe('status');
-      expect(error.message).toContain('Invalid status');
+      expect(error.message).toContain('status must be one of');
       expect(error.message).toContain('Owned');
     });
   });

--- a/tests/unit/collection/ui/components/GameForm/GameForm.test.tsx
+++ b/tests/unit/collection/ui/components/GameForm/GameForm.test.tsx
@@ -147,7 +147,7 @@ describe('GameForm', () => {
       await user.click(screen.getByRole('button', { name: /add game/i }));
 
       await waitFor(() => {
-        expect(screen.getByText('Game title cannot be empty')).toBeInTheDocument();
+        expect(screen.getByText('title cannot be empty')).toBeInTheDocument();
       });
     });
 
@@ -159,7 +159,7 @@ describe('GameForm', () => {
       await user.click(screen.getByRole('button', { name: /add game/i }));
 
       await waitFor(() => {
-        expect(screen.getByText('Platform name is required')).toBeInTheDocument();
+        expect(screen.getByText('platform cannot be empty')).toBeInTheDocument();
       });
     });
 
@@ -171,7 +171,7 @@ describe('GameForm', () => {
 
       await waitFor(() => {
         const titleInput = screen.getByRole('textbox', { name: /game title/i });
-        expect(titleInput).toHaveAccessibleErrorMessage('Game title cannot be empty');
+        expect(titleInput).toHaveAccessibleErrorMessage('title cannot be empty');
       });
     });
 

--- a/tests/unit/toast/domain/value-objects/ToastDuration.test.ts
+++ b/tests/unit/toast/domain/value-objects/ToastDuration.test.ts
@@ -31,6 +31,22 @@ describe('ToastDuration', () => {
       expect(result.isErr()).toBeTruthy();
       expect(result.getError().field).toBe('duration');
     });
+
+    it('should return error for NaN', () => {
+      const result = ToastDuration.create(NaN);
+
+      expect(result.isErr()).toBeTruthy();
+      expect(result.getError().field).toBe('duration');
+      expect(result.getError().message).toBe('duration must be a positive number');
+    });
+
+    it('should return error for Infinity', () => {
+      const result = ToastDuration.create(Infinity);
+
+      expect(result.isErr()).toBeTruthy();
+      expect(result.getError().field).toBe('duration');
+      expect(result.getError().message).toBe('duration must be a positive number');
+    });
   });
 
   describe('getValue', () => {


### PR DESCRIPTION
# Pull Request

## Description

Refactor all Value Objects across the `collection` and `toast` bounded contexts to eliminate
duplicated inline validation logic by introducing `AbstractStringValueObject` and
`AbstractNumberValueObject` in `src/shared/domain/value-objects/`. Validation helpers are
`protected static`, restricting their use to VO subclasses and keeping `create()` and `getXXX()`
as the sole public API. `MaxLengthError` is added to the shared error catalogue and a latent
`NaN`/`Infinity` edge case in numeric validation is fixed.

## Related Issue

Closes #285

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔨 Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] 📝 Documentation update
- [x] 🧪 Test update
- [ ] 🎨 UI/UX change
- [ ] ⚡ Performance improvement
- [ ] ♿ Accessibility improvement

## Changes Made

- Add `AbstractStringValueObject` with `protected static` helpers: `trim()`, `notEmpty()`, `maxLength()`
- Add `AbstractNumberValueObject` with `protected static` helper: `positiveNumber()` (fixes `NaN`/`Infinity` edge case — old `value <= 0` guard silently accepted `NaN`)
- Add `MaxLengthError` to the shared domain errors catalogue
- Refactor 6 collection VOs (`GameTitle`, `GameId`, `Format`, `Platform`, `GameDescription`, `Status`) to extend the abstract bases
- Refactor 3 toast VOs (`ToastMessage`, `ToastId`, `ToastDuration`) to extend the abstract bases
- Remove all local anonymous error types from VO files, `Game.ts`, and `GameMapper.ts`; replace with `DomainValidationErrorInterface`
- Add ADR-018 documenting the architectural decision
- Update `docs/value-objects.md`, `DECISIONS.md`, `docs/README.md`, and `docs/architecture/adr/README.md`

## Architecture Layer(s) Affected

- [x] Domain (entities, value objects, domain logic)
- [ ] Application (use cases, ports/interfaces)
- [x] Infrastructure (repositories, adapters, external services)
- [ ] Presentation (UI components, views, controllers)

## Testing

### Test Coverage

- [x] Unit tests added/updated (9 VO/entity unit test files updated to reflect standardised error messages)
- [ ] Integration tests added/updated
- [x] Component tests added/updated (`GameForm.test.tsx` updated)
- [x] E2E tests added/updated (`tests/e2e/add-game.test.ts` — 3 error message assertions updated)
- [x] All existing tests pass (432 unit tests + 21 E2E tests)

### Manual Testing

1. Run `npm run test:unit` — verify all 432 unit tests pass
2. Run `npm run test:e2e` — verify all 21 E2E tests pass
3. Run `npm run lint` — verify no errors or warnings
4. Run `npm run lint:tsc` — verify TypeScript strict mode clean

## Accessibility

N/A — domain layer refactoring only, no UI changes.

## Screenshots / Videos

N/A — no UI changes.

## Browser/Device Testing

N/A — domain layer refactoring only.

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance regression (explain below)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Checklist

- [x] Code follows the project's Clean Architecture guidelines
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (ADR-018, value-objects.md, DECISIONS.md, docs/README.md, docs/architecture/adr/README.md)
- [x] No new warnings or errors introduced
- [x] Dependent changes merged and published (if applicable)

## Additional Notes

**Alignment verification**: ✅ All acceptance criteria from issue #285 are implemented. The issue proposed `public static` helpers; the final implementation deliberately uses `protected static` to prevent external callers from invoking validation helpers directly — only `create()` and `getXXX()` remain part of the public VO API. This decision is documented in ADR-018.

`Status` VO is the only VO that does not extend `AbstractStringValueObject` — its validation is enum-based (`AllowedValuesError`), not a string-length concern.