### PR TITLE
ci: add workflow to manage Renovate PR limits

### DIFF
--- a/.github/workflows/renovate-update-limits.yml
+++ b/.github/workflows/renovate-update-limits.yml
@@ -1,0 +1,26 @@
+name: Update Renovate PR Limits
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: >
+          New limit for prConcurrentLimit and prHourlyLimit (e.g. 5, 0 = unlimited),
+          or "reset" to remove local overrides and restore shared config defaults.
+        required: true
+        type: string
+        default: 'reset'
+
+jobs:
+  update-renovate-limits:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Update Renovate limits
+        uses: pplancq/actions/renovate-update-limits@745b7a9f48e9670336d693310d022866a0e0da53 # v1.1.0
+        with:
+          limit: ${{ inputs.limit }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@pplancq/commitlint-config": "^4.0.0",
         "@pplancq/eslint-config": "^6.0.15",
         "@pplancq/postcss-config": "^3.0.5",
-        "@pplancq/prettier-config": "^2.0.2",
+        "@pplancq/prettier-config": "^3.0.0",
         "@pplancq/stylelint-config": "^5.0.3",
         "@rsbuild/core": "^2.0.6",
         "@rsbuild/plugin-eslint": "^2.0.0",
@@ -2253,26 +2253,24 @@
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "32.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-32.2.0.tgz",
-      "integrity": "sha512-X8xuVhSIqlUjxSRifRJ7t0TycVWyX58fygJH3wDNmHINLg9sYEkvQT0SO2G5YlRZnYc11TIFr4YPenscvdlBIw==",
+      "version": "39.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-39.1.0.tgz",
+      "integrity": "sha512-pqmSO2bUWxJm3TbNrKXlDaHjL6c77+ez9kWmfCd9oRPeTRPEVH3spZvpAqdXYWOZYSNYwWFCAAeZ4RGpkauNoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <28"
+        "@cucumber/messages": ">=31.0.0 <33"
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
-      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
+      "version": "32.3.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.3.1.tgz",
+      "integrity": "sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "11.0.5"
+        "reflect-metadata": "0.2.2"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3689,13 +3687,13 @@
       }
     },
     "node_modules/@pplancq/prettier-config": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@pplancq/prettier-config/-/prettier-config-2.0.2.tgz",
-      "integrity": "sha512-gM1QsydO5AZzOL8eeZNecjQQ6wWj19A0RugvtsBlpBhCB5EAIaJy/uxsqyx72GPGMTx48y97U0OitsB7QkH9Lw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@pplancq/prettier-config/-/prettier-config-3.0.0.tgz",
+      "integrity": "sha512-5tJC5wDgaQp5l37eM8aaX2U1ANek5tt67PvgoHDvjfGOlQJl6HFvPRzRWc6GyETiQW5OaOXhW/yLBQxnqpuFcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prettier-plugin-gherkin": "^3.1.4",
+        "prettier-plugin-gherkin": "^4.0.0",
         "prettier-plugin-nginx": "^1.0.3",
         "prettier-plugin-properties": "^0.3.1",
         "prettier-plugin-sh": "^0.18.1"
@@ -3704,7 +3702,7 @@
         "init-prettier-config": "bin/init.mjs"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
         "prettier": "^3.1.1"
@@ -4815,13 +4813,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -6327,9 +6318,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12583,14 +12574,14 @@
       }
     },
     "node_modules/prettier-plugin-gherkin": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-gherkin/-/prettier-plugin-gherkin-3.1.4.tgz",
-      "integrity": "sha512-Mccs8tUhv7iCAhSkgvdupuJt5nj28UK6Ixsmui6TdVnvDRwy4wwEKv6du4mdMB2S7Oj0xQPTNO53Jo8alj+1bg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-gherkin/-/prettier-plugin-gherkin-4.0.0.tgz",
+      "integrity": "sha512-EBDwV1Ou9rG+seoh7jcwZ6sXXyHwsbUks5TeSyrlrLaTdz+/qYvnHuwY8rk7mb6/+M1ZGuY4/SiVc68ybwvJOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/gherkin": "^32.0.0",
-        "@cucumber/messages": "^27.2.0",
+        "@cucumber/gherkin": "^39.1.0",
+        "@cucumber/messages": "^32.3.1",
         "prettier": "^3.5.3"
       }
     },
@@ -15306,20 +15297,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/varint": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@pplancq/commitlint-config": "^4.0.0",
     "@pplancq/eslint-config": "^6.0.15",
     "@pplancq/postcss-config": "^3.0.5",
-    "@pplancq/prettier-config": "^2.0.2",
+    "@pplancq/prettier-config": "^3.0.0",
     "@pplancq/stylelint-config": "^5.0.3",
     "@rsbuild/core": "^2.0.6",
     "@rsbuild/plugin-eslint": "^2.0.0",


### PR DESCRIPTION
# Pull Request

## Description

Add a manual GitHub Actions workflow to dynamically control Renovate's `prConcurrentLimit`
and `prHourlyLimit` values in `.github/renovate.json`. The workflow accepts a single numeric
input applied to both limits, or `"reset"` to remove local overrides and fall back to the
shared `pplancq/renovate-config` defaults. The logic is extracted into a reusable composite
action published in `pplancq/actions@v1.1.0`.

## Related Issue

<!-- No linked issue — operational tooling workflow -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📝 Documentation update
- [ ] 🧪 Test update
- [ ] 🎨 UI/UX change
- [ ] ⚡ Performance improvement
- [ ] ♿ Accessibility improvement
- [x] 🤖 CI/CD improvement

## Changes Made

- Add `.github/workflows/renovate-update-limits.yml`: `workflow_dispatch` with a single `limit` input (number or `"reset"`)
- Delegate logic to reusable composite action `pplancq/actions/renovate-update-limits@745b7a9 # v1.1.0`
- Input validation rejects any value that is not a non-negative integer or `"reset"`
- Skips commit when the file is already up to date (idempotent)

## Architecture Layer(s) Affected

- [ ] Domain (entities, value objects, domain logic)
- [ ] Application (use cases, ports/interfaces)
- [ ] Infrastructure (repositories, adapters, external services)
- [ ] Presentation (UI components, views, controllers)

> CI/CD configuration only — no application layer affected.

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Component tests added/updated (if UI)
- [ ] E2E tests added/updated (if critical flow)
- [x] All existing tests pass

### Manual Testing

1. Go to **Actions → Update Renovate PR Limits → Run workflow**
2. Enter a numeric value (e.g. `5`) and verify `.github/renovate.json` is updated with `"prConcurrentLimit": 5` and `"prHourlyLimit": 5`
3. Run again with `reset` and verify both fields are removed from the file
4. Run again with the current value already set and verify no commit is created

## Accessibility

N/A — no UI changes.

## Screenshots / Videos

N/A — CI workflow only.

## Browser/Device Testing

N/A — CI workflow only.

## Performance Impact

- [x] No significant performance impact

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] Code follows the project's Clean Architecture guidelines
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings or errors introduced
- [x] Dependent changes merged and published (`pplancq/actions@v1.1.0` released)

## Additional Notes

The reusable composite action is published in `pplancq/actions` and pinned to a specific
commit SHA (`745b7a9 # v1.1.0`) following the existing SHA-pinning convention of this repo.
Renovate will automatically keep this SHA up to date.

⚠️ The diff also includes a `chore(deps)` commit updating `@pplancq/prettier-config` — this
is an unrelated dependency update that was merged into this branch from `main`.